### PR TITLE
feat(options): add option to use notify api instead of echo

### DIFF
--- a/lua/ohne-accidents.lua
+++ b/lua/ohne-accidents.lua
@@ -2,15 +2,29 @@
 
 local M = {}
 
+---@class OhneAccidentsConfig
+---@field welcomeOnStartup? boolean Choose whether to display the welcome message on startup.
+---@field api? "echo" | "notify" Choose whether to use `echo` or `vim.notify` to display the message.
 M.config = {
     welcomeOnStartup = true,
+    api = "echo",
 }
 
 function M.setConfig(opts)
-    for k, v in pairs(opts) do
-        if M.config[k] ~= nil then
-            M.config[k] = v
-        end
+    M.config = vim.tbl_deep_extend("force", M.config, opts)
+end
+
+function M.notify(message)
+    if M.config.api == "echo" then
+        vim.api.nvim_echo({ { message, "Title" } }, true, {})
+    end
+
+    if M.config.api == "notify" then
+        vim.api.nvim_notify(message, vim.log.levels.INFO, { title = " Ohne Accidents" })
+    end
+
+    if M.config.api ~= "echo" and M.config.api ~= "notify" then
+        error("Invalid notifyApi option")
     end
 end
 
@@ -46,7 +60,8 @@ function M.welcomeOnStartup()
         "╔════╗\n║ %2d ║ Days Without Editing the Configuration\n╚════╝",
         days
     )
-    vim.api.nvim_echo({ { message, "Title" } }, true, {})
+
+    M.notify(message)
 end
 
 function M.displayDetailedMessage()
@@ -58,7 +73,8 @@ function M.displayDetailedMessage()
         minutes,
         seconds
     )
-    vim.api.nvim_echo({ { message, "Title" } }, true, {})
+
+    M.notify(message)
 end
 
 function M.setup(opts)

--- a/lua/ohne-accidents.lua
+++ b/lua/ohne-accidents.lua
@@ -4,9 +4,11 @@ local M = {}
 
 ---@class OhneAccidentsConfig
 ---@field welcomeOnStartup? boolean Choose whether to display the welcome message on startup.
+---@field multiLine? boolean Choose wether the message should be displayed in a single line or multiple lines.
 ---@field api? "echo" | "notify" Choose whether to use `echo` or `vim.notify` to display the message.
 M.config = {
     welcomeOnStartup = true,
+    multiLine = true,
     api = "echo",
 }
 
@@ -56,25 +58,44 @@ function M.welcomeOnStartup()
     end
 
     local days = timeSinceLastChange()
-    local message = string.format(
-        "╔════╗\n║ %2d ║ Days Without Editing the Configuration\n╚════╝",
-        days
-    )
 
-    M.notify(message)
+    if M.config.multiLine then
+        local message = string.format(
+            "╔════╗\n║ %2d ║ Days Without Editing the Configuration\n╚════╝",
+            days
+        )
+        M.notify(message)
+    else
+        local message = string.format("%2d Days Without Editing the Configuration", days)
+
+        M.notify(message)
+    end
 end
 
 function M.displayDetailedMessage()
     local days, hours, minutes, seconds = timeSinceLastChange()
-    local message = string.format(
-        "╔════╗\n║ %2d ║ Days\n║ %2d ║ Hours\n║ %2d ║ Minutes\n║ %2d ║ Seconds\n╚════╝ Without Editing the Configuration",
-        days,
-        hours,
-        minutes,
-        seconds
-    )
 
-    M.notify(message)
+    if M.config.multiLine then
+        local message = string.format(
+            "╔════╗\n║ %2d ║ Days\n║ %2d ║ Hours\n║ %2d ║ Minutes\n║ %2d ║ Seconds\n╚════╝ Without Editing the Configuration",
+            days,
+            hours,
+            minutes,
+            seconds
+        )
+
+        M.notify(message)
+    else
+        local message = string.format(
+            "%2d Days, %2d Hours, %2d Minutes, %2d Seconds Without Editing the Configuration.",
+            days,
+            hours,
+            minutes,
+            seconds
+        )
+
+        M.notify(message)
+    end
 end
 
 function M.setup(opts)

--- a/readme.md
+++ b/readme.md
@@ -8,34 +8,84 @@ This is a simple plugin that tells you how many days have passed without you tou
 
 With [lazy.nvim](https://github.com/folke/lazy.nvim)
 
-```lazy
-  {
+```lua
+{
     'blumaa/ohne-accidents.nvim',
-    config = function()
-      require("ohne-accidents").setup()
-      vim.api.nvim_set_keymap('n', '<leader>oh', ':OhneAccidents<CR>', {noremap = true, silent = true})
-    end
-  },
-
+    event = "UIEnter", -- Optional, but recommended event if you want to lazy load the plugin.
+    ---@type OhneAccidentsConfig
+    opts = {}, -- Setting this to {} will use the default configuration and load the plugin.
+    keys = {
+        {
+            "<leader>oh",
+            ":OhneAccidents<CR>",
+            desc = "Time since last config change"
+        },
+    },
+}
 ```
 
 ### Configuration
 
-The welcome message is set to display by default when you start nvim. You can turn this off by setting it to false.
+This is the default configuration, and their description:
 
+```lua
+---@class OhneAccidentsConfig
+---@field welcomeOnStartup? boolean Choose whether to display the welcome message on startup.
+---@field api? "echo" | "notify" Choose whether to use `echo` or `vim.notify` to display the message.
+M.config = {
+    welcomeOnStartup = true,
+    api = "echo",
+}
 ```
-  require("ohne-accidents").setup({ welcomeOnStartup = false })
+
+To set these options, and if you use `lazy.nvim`, you can use the `opts` field like this:
+
+```lua
+{
+    'blumaa/ohne-accidents.nvim',
+    -- ..
+    ---@type OhneAccidentsConfig
+    opts = {
+        welcomeOnStartup = false,
+        api = "notify",
+    },
+    -- ..
+}
+```
+
+You can also just use the `setup()` function like this:
+
+```lua
+require('ohne-accidents').setup({
+    welcomeOnStartup = false,
+    api = "notify"
+})
 ```
 
 ### Detailed Display Message
 
 ![exampe of detailed display message](images/detailedDisplayMessage.png)
 
-When you open vim, if you have not set the welcomeOnStartup message to false, only the days will appear in the welcome message. If you want a detailed display message, you can type `:OhneAccidents` or set your own keybidning for it like this:
+When you open vim, if you have not set the `welcomeOnStartup` message to `false`, only the days will appear in the welcome message. If you want a detailed display message, you can type `:OhneAccidents` or set your own keybidning for it like this:
 
+```lua
+vim.api.nvim_set_keymap('n', '<leader>oh', ':OhneAccidents<CR>', { noremap = true, silent = true})
 ```
-    vim.api.nvim_set_keymap('n', '<leader>oh', ':OhneAccidents<CR>', {noremap = true, silent = true})
 
+Or set the binding via the `lazy.nvim` `keys` API:
+
+```lua
+{
+    'blumaa/ohne-accidents.nvim',
+    -- ..
+    keys = {
+    {
+        "<leader>oh",
+        ":OhneAccidents<CR>",
+        desc = "Time since last config change"
+    },
+    -- ..
+}
 ```
 
 Look at the installation example above to see where to put the keybinding.

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ With [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lazy
   {
-    'blumaa/ohne-accidents',
+    'blumaa/ohne-accidents.nvim',
     config = function()
       require("ohne-accidents").setup()
       vim.api.nvim_set_keymap('n', '<leader>oh', ':OhneAccidents<CR>', {noremap = true, silent = true})
@@ -42,7 +42,7 @@ Look at the installation example above to see where to put the keybinding.
 
 ### Alternatives
 
-- [ConfigPulse](https://github.com/mrquantumcodes/configpulse)
-- [NvimDaysWithout](https://github.com/idanarye/nvim-days-without)
+-   [ConfigPulse](https://github.com/mrquantumcodes/configpulse)
+-   [NvimDaysWithout](https://github.com/idanarye/nvim-days-without)
 
 Each of these works just a little bit differently than ohne-accidents. NvimDaysWithout uses git to calculate things. ConfigPulse uses the config folder but doesn't display a welcome message when you open nvim.


### PR DESCRIPTION
- [x] Option: `api` to choose notification API
- [ ] Option: `formatting` to choose multi/single-line notification
	- To make it workable for notification plugins, which use only one line for one notification. (e.g. "mini.notify")
- [ ] Update readme

## Optional future

- [ ] Option: `gitMode` - Use time since last commit as "time since last change"
	- with additional text, if there are uncommited changes
